### PR TITLE
typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Vue.component('vue-easymde', VueEasymde)
 ## Methods
 
 ``` js
-this.$refs.markdownEditor.simplemde.togglePreview();
+this.$refs.markdownEditor.easymde.togglePreview();
 ```
 
 [examples/index.vue](./examples/index.vue)


### PR DESCRIPTION
`this.$refs.markdownEditor.simplemde` is not defined.